### PR TITLE
chore: bump rust-crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 rusqlite = "0.17.0"
 plist = "0.5.1"
 dirs = "1.0.5"
-rust-crypto = "^0.2"
+rust-crypto = "0.2.36"
 colored = "1.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.10.5"


### PR DESCRIPTION
fixes security issues discovered in rust-crypto